### PR TITLE
Changes to get pytest/ci actions to run again

### DIFF
--- a/python/data_structures/hashtable.py
+++ b/python/data_structures/hashtable.py
@@ -1,6 +1,5 @@
 from data_structures.linked_list import LinkedList
 
-
 class Hashtable:
     """
     Put docstring here

--- a/python/data_structures/hashtable.py
+++ b/python/data_structures/hashtable.py
@@ -1,4 +1,4 @@
-from python.data_structures.linked_list import LinkedList
+from data_structures.linked_list import LinkedList
 
 
 class Hashtable:


### PR DESCRIPTION
We're all good now! Fixed:

- A file was trying to import from python.data_structures rather than data_structures, resulting in python module not found error.
- An `__init__.py` was in a place that results in this error, again resulting in a module not found error.

Both changes are needed to get the pytest tests to run again. A few tests fail but that's because of legitimate test failures to work through.